### PR TITLE
feat(config): fix solc version for ci builds

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,7 @@ script = 'scripts'
 test = 'tests'
 out = "out"
 libs = ["lib"]
+solc = '0.8.18'
 
 [rpc_endpoints]
 mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}"


### PR DESCRIPTION
## Description

Fix solc version for CI Builds 
We're using 0.8.18, by default foundry uses latest solc version (auto_detect_solc = true), so setting this to 0.8.18 for all builds

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs
- [x] 🙅 no documentation needed

